### PR TITLE
Allow us to push the real sha

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:290.0.1-alpine
+FROM google/cloud-sdk:alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/push/Dockerfile
+++ b/push/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:290.0.1-alpine
+FROM google/cloud-sdk:alpine
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]


### PR DESCRIPTION
Github actions creates a merge commit before the run is started.
This can be overridden with
```
    steps:
      - uses: actions/checkout@v2
        with:
          ref: ${{ github.event.pull_request.head.sha }}
```
But then we need to use that SHA inside the build and push too...